### PR TITLE
Fix committer info

### DIFF
--- a/.github/workflows/m3u_Generator.yml
+++ b/.github/workflows/m3u_Generator.yml
@@ -6,11 +6,11 @@ name: M3U generator
 on:
   schedule:
     - cron: '0 0/3 * * *'
-    
+
   pull_request:
     branches:
       - main
-  
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -33,24 +33,21 @@ jobs:
       # Runs a set of commands using the runners shell 
       - name: config
         run: |
-          git config --global user.email "unnik1998@gmail.com"
-          git config --global user.name "benmoose39"
-      
-      
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Main
         run: |
           pwd
           chmod +x autorun.sh
           ./autorun.sh
-        
+
       - name: git add
         run: |
           git add -A
-          ls -la 
-          
+          ls -la
+
       - name: commit & push
         run: |
           git commit -m "links are updated"
           git push
-          
-          


### PR DESCRIPTION
I have changed committer of cron CI from benmoose39 into actions-user.
`benmoose39 <unnik1998@gmail.com>`->`GitHub Action <action@github.com>`

Example: https://github.com/eggplants/nijisanji-v23d-status/commits/master  
![image](https://user-images.githubusercontent.com/42153744/144709883-d9a53cd4-78ff-4bda-a44b-c247315ca035.png)
